### PR TITLE
added review-bot

### DIFF
--- a/.github/review-bot.yml
+++ b/.github/review-bot.yml
@@ -1,0 +1,33 @@
+rules:
+  - name: CI Files
+    condition:
+      include:
+        - ^\.github/.*
+    type: fellows
+    minRank: 3
+    minTotalScore: 15
+  - name: Proposals
+    condition:
+      include:
+        - ^proposals\/.*
+    type: fellows
+    minRank: 2
+    minApprovals: 2
+    minTotalScore: 10
+  - name: General Files
+    condition:
+      include:
+        - '.*'
+    type: fellows
+    minRank: 1
+    minTotalScore: 4
+scores:
+  dan1: 1
+  dan2: 2
+  dan3: 5
+  dan4: 9
+  dan5: 10
+  dan6: 15
+  dan7: 20
+  dan8: 25
+  dan9: 30

--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -1,0 +1,34 @@
+name: Review Bot
+
+on:
+  workflow_run:
+    workflows:
+      - Review-Trigger
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  review-approvals:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract content of artifact
+        id: number
+        uses: Bullrich/extract-text-from-artifact@v1.0.0
+        with:
+          artifact-name: pr_number
+      - name: Generate token
+        id: team_token
+        uses: actions/create-github-app-token@v1.9.3
+        with:
+          app-id: ${{ secrets.REVIEW_APP_ID }}
+          private-key: ${{ secrets.REVIEW_APP_KEY }}
+      - name: "Evaluates PR reviews and assigns reviewers"
+        uses: paritytech/review-bot@v2.5.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          team-token: ${{ steps.team_token.outputs.token }}
+          checks-token: ${{ steps.team_token.outputs.token }}
+          pr-number: ${{ steps.number.outputs.content }}

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -1,0 +1,72 @@
+name: Review-Trigger
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - review_requested
+      - review_request_removed
+      - ready_for_review
+  pull_request_review:
+
+jobs:
+  trigger-review-bot:
+    # (It is not a draft) && (it is not a review || it is an approving review)
+    if: ${{ github.event.pull_request.draft != true && (github.event_name != 'pull_request_review' || (github.event.review && github.event.review.state == 'APPROVED')) }}
+    runs-on: ubuntu-latest
+    name: trigger review bot
+    steps:
+      - name: Get PR data
+        id: comments
+        run: |
+          echo "bodies=$(gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json comments --jq '[.comments[].body]')" >> "$GITHUB_OUTPUT"
+          echo "reviews=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --jq '[.[].state]')" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Get the GitHub handle of the fellows
+        uses: paritytech/get-fellows-action@v1.1.3
+        id: fellows
+        # Require new reviews when the author is pushing and he is not a fellow
+      - name: Fail when author pushes new code
+        # if (contains approved reviews && it's a synchronize event && was triggered by the author (who is not a fellow))
+        if: |
+          contains(fromJson(steps.comments.outputs.reviews), 'APPROVED') &&
+          github.event_name == 'pull_request_target' &&
+          github.event.action == 'synchronize' && 
+          github.event.sender.login == github.event.pull_request.user.login && 
+          contains(steps.fellows.outputs.github-handles, github.event.pull_request.user.login)
+        run: |
+          # We get the list of reviewers who approved the PR
+          REVIEWERS=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews \
+          --jq '{reviewers: [.[] | select(.state == "APPROVED") | .user.login]}')
+
+          # We request them to review again
+          echo $REVIEWERS | gh api --method POST repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers --input -
+
+          echo "::error::Project needs to be reviewed again"
+          exit 1
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Comment requirements
+        # If the previous step failed and github-actions hasn't commented yet we comment instructions
+        if: failure() && !contains(fromJson(steps.comments.outputs.bodies), 'Review required! Latest push from author must always be reviewed')
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body "Review required! Latest push from author must always be reviewed"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENTS: ${{ steps.comments.outputs.users }}
+      - name: Get PR number
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "Saving PR number: $PR_NUMBER"
+          mkdir -p ./pr
+          echo $PR_NUMBER > ./pr/pr_number
+      - uses: actions/upload-artifact@v4
+        name: Save PR number
+        with:
+          name: pr_number
+          path: pr/
+          retention-days: 5


### PR DESCRIPTION
Now that polkadot-fellows/xcm-format#65 has been resolved, review-bot can be implemented.

I copied the workflow files from the [`runtimes`](https://github.com/polkadot-fellows/runtimes) repository.

Resolves #62 

The following configuration has been writen in the file, but it can be changed if you disagree with the rules:

### CI Files
Requires **1 dan 3** to review it and a total of **15 points** to merge.

Some possible combinations are:
- 1 `dan6`
- 1 `dan5` & 1 `dan3`
- 3 `dan3`
- 1 `dan4` & 1 `dan3` & `1 dan2`

### Proposals
Requires at least **2 dan 2** to review it and a total of **10 points** to merge.

Some possible combinations are:
- 1 `dan5` & any rank
- 2 `dan3`.
- 5 `dan2`.
- 1 `dan2` and 8 `dan1`.

### General files
Requires at least **2 dan 1** to review it and a total of **4 points** to merge.

Some possible combinations are:
- 1 `dan3` or above.
- 4 `dan1`.
- 2 `dan2`.