### PR TITLE
added auto-merge and up-to-date GitHub actions

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,30 @@
+name: Auto Merge Bot
+
+on:
+  # GitHub considers PRs as issues
+  issue_comment:
+    types: [created]
+
+jobs:
+  set-auto-merge:
+    runs-on: ubuntu-latest
+    environment: master
+    timeout-minutes: 10
+    # Important! This forces the job to run only on comments on Pull Requests that starts with '/merge'
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/merge') }}
+    steps:
+      - name: Get the GitHub handle of the fellows
+        uses: paritytech/get-fellows-action@v1.1.3
+        id: fellows
+      - name: Generate a token
+        id: merge_token
+        uses: actions/create-github-app-token@v1.8.1
+        with:
+          app-id: ${{ secrets.MERGE_APP_ID }}
+          private-key: ${{ secrets.MERGE_APP_KEY }}
+      - name: Set auto merge
+        uses: paritytech/auto-merge-bot@v1.0.1
+        with:
+          GITHUB_TOKEN: ${{ steps.merge_token.outputs.token }}
+          MERGE_METHOD: "SQUASH"
+          ALLOWLIST: ${{ steps.fellows.outputs.github-handles }}

--- a/.github/workflows/up-to-date.yml
+++ b/.github/workflows/up-to-date.yml
@@ -1,0 +1,23 @@
+name: Keep PR up to date
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  updatePullRequests:
+    name: Keep PRs up to date
+    runs-on: ubuntu-latest
+    environment: master
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.MERGE_APP_ID }}
+          private-key: ${{ secrets.MERGE_APP_KEY }}
+      - name: Update all the PRs
+        uses: paritytech/up-to-date-action@v0.2.1
+        with:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
Once polkadot-fellows/xcm-format#67 is complete, we can enable this bots

They **will not work until they are merged**.

This enabled [auto-merge-bot](https://github.com/paritytech/auto-merge-bot) so we can enable auto merge running the `/merge` command and [up-to-date action](https://github.com/paritytech/up-to-date-action) so we can keep all the PRs up to date.

This PR partially resolves #62 